### PR TITLE
More Improvements (see full info)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-node_modules/
+node_modules
 yarn.lock

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
 The MIT License (MIT)
 
 Copyright (c) 2019-present Wessel "wesselgame" T

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ const w = require('wumpfetch');
 		.timeout(1000) // Set a 1s timeout
 		.query('video', 'wumpboye') // Add a query
 		.header({ 'Authorization': 'Pablito' }) // Set a header
-		.body({ x: 'y', z: 1, beep: 'boop', chocolate: true }) // Send a json body
+		.body({ x: 'y', z: 1, beep: 'boop', chocolate: true }) // Send a JSON body
 		.send(); // Finish the chain by sending the rquest
 
 	console.log(r.json()); // Returns the response in a JSON format
@@ -51,9 +51,7 @@ const w = require('wumpfetch');
 		url: 'https://my-site.com/postboi',
 		data: { 'bear': 'cop' },
 		method: 'POST',
-		headers: {
-			'Authorization': 'Pablo'
-		}
+		headers: { 'Authorization': 'Pablo' }
 	});
 
 	console.log(r.json());
@@ -68,8 +66,3 @@ const w = require('wumpfetch');
 	console.log(r.json());
 })();
 ```
-
-### Why use Wumpfetch?
-Wumpfetch is a lightweight and fast request library comparing to other packages such as request which is 4.46mb!
-<br>
-[![install size](https://packagephobia.now.sh/badge?p=wumpfetch)](https://packagephobia.now.sh/result?p=wumpfetch) (6.2kb concatenated and 4.4kb minified, both in **/dest**)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,17 +1,17 @@
-const gulp = require('gulp');
-const minify = require('gulp-minify');
-const concat = require('gulp-concat');
+const g = require('gulp');
+const m = require('gulp-minify');
+const c = require('gulp-concat');
 
-gulp.task('build:node', () => {
-  return gulp
+g.task('build:node', () => {
+  return g
     .src('dist/wumpfetch.concat.js')
-    .pipe(minify({ noSource: true, ext: { min: '.min.js' } }))
-    .pipe(gulp.dest('dist'));
+    .pipe(m({ noSource: true, ext: { min: '.min.js' } }))
+    .pipe(g.dest('dist'));
 });
 
-gulp.task('concat', () => {
-  return gulp
+g.task('concat', () => {
+  return g
     .src('lib/**/*.js')
-    .pipe(concat('wumpfetch.concat.js'))
-    .pipe(gulp.dest('dist'));
+    .pipe(c('wumpfetch.concat.js'))
+    .pipe(g.dest('dist'));
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,17 +1,18 @@
+const req = require('./model/WumpRequest');
+const pkg = require('../package.json');
+
 const common = [ 'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH' ];
-const request = require('./model/WumpRequest');
-const { version } = require('../package.json');
 
 module.exports = (url, method) => {
-  return new request(url, method);
+  return new req(url, method);
 };
 
 common.forEach((v) => {
   module.exports[v.toLowerCase()] = (url, method) => {
-    if (typeof url === 'string') return new request(url, { method: v, ...method });
-    else return new request({ method: v, ...url }, method);
+    if (typeof url === 'string') return new req(url, { method: v, ...method });
+    else return new req({ method: v, ...url }, method);
   }
 });
 
-module.exports.version = version;
-module.exports.userAgent = `wumpfetch/${version} (https://github.com/PassTheWessel/wumpfetch)`;
+module.exports.version = pkg.version;
+module.exports.userAgent = `${pkg.name}/${pkg.version} (${pkg.git.repository})`;

--- a/lib/model/WumpRequest.js
+++ b/lib/model/WumpRequest.js
@@ -1,11 +1,12 @@
-const http = require('http');
-const https = require('https');
-const { URL } = require('url');
-const { join } = require('path');
-const { stringify } = require('querystring');
-const { createGunzip, createInflate } = require('zlib');
+const h = require('http');
+const hs = require('https');
+const u = require('url');
+const pa = require('path');
+const qs = require('querystring');
+const zl = require('zlib');
 
-const WumpResponse = require('./WumpResponse');
+const WumpRes = require('./WumpResponse');
+const pkg = require('../package.json');
 
 const w = require('../index');
 const c = [ 'gzip', 'deflate' ];
@@ -19,9 +20,9 @@ module.exports = class WumpRequest {
 
 		this.o = {
 			'm': typeof o === 'string' ? o : obj && o.method ? o.method : 'GET',
-			'url': typeof url === 'string' ? new URL(url) : obj && typeof o.url === 'string' ? new URL(o.url) : url,
+			'url': typeof url === 'string' ? new u.URL(url) : obj && typeof o.url === 'string' ? new u.URL(o.url) : url,
 			'SDA': obj && typeof o.sendDataAs === 'string' ? o.sendDataAs : obj && o.data && typeof o.data === 'object' ? 'json' : undefined,
-			'data': obj && o.body ? o.body : obj && o.data ? o.data : obj && o.json ? o.json : obj && o.form ? stringify(o.form) : undefined,
+			'data': obj && o.body ? o.body : obj && o.data ? o.data : obj && o.json ? o.json : obj && o.form ? qs.stringify(o.form) : undefined,
 			'parse': obj && o.parse ? o.parse : undefined,
 			'follow': !!(obj && o.followRedirects),
 			'rHeaders': obj && typeof o.headers === 'object' ? o.headers : {},
@@ -45,7 +46,7 @@ module.exports = class WumpRequest {
 
 	body (data, SA) {
 		this.o.SDA = typeof data === 'object' && !SA && !Buffer.isBuffer(data) ? 'json' : (SA ? SA.toLowerCase() : 'buffer');
-		this.o.data = this.SDA === 'form' ? stringify(data) : (this.SDA === 'json' ? JSON.stringify(data) : data);
+		this.o.data = this.SDA === 'form' ? qs.stringify(data) : (this.SDA === 'json' ? JSON.stringify(data) : data);
 
 		return this;
 	}
@@ -65,7 +66,7 @@ module.exports = class WumpRequest {
 	}
 	
 	path (p) {
-		this.o.url.pathname = join(this.o.url.pathname, p);
+		this.o.url.pathname = pa.join(this.o.url.pathname, p);
 
 		return this;
 	}
@@ -90,7 +91,7 @@ module.exports = class WumpRequest {
 	send () {
 		return new Promise((resolve, reject) => {
 			if (this.o.data) {
-				if (!this.o.rHeaders.hasOwnProperty('user-agent')) this.o.rHeaders['User-Agent'] = w.userAgent || 'Wumpfetch/2.0.1 (https://github.com/PassTheWessel/wumpfetch)';
+				if (!this.o.rHeaders.hasOwnProperty('user-agent')) this.o.rHeaders['User-Agent'] = w.userAgent || `${pkg.name}/${pkg.version} (${pkg.git.repository})`;
 				
 				if (this.o.SDA === 'json' && !this.o.rHeaders.hasOwnProperty('content-type')) this.o.rHeaders['Content-Type'] = 'application/json';
 				if (this.o.SDA === 'form') {
@@ -114,18 +115,18 @@ module.exports = class WumpRequest {
 				let stream = res;
 
 				if (this.o.compressed) {
-					if (res.headers['content-encoding'] === 'gzip') stream = res.pipe(createGunzip());
-					else if (res.headers[ 'content-encoding'] === 'deflate') stream = res.pipe(createInflate());
+					if (res.headers['content-encoding'] === 'gzip') stream = res.pipe(zl.createGunzip());
+					else if (res.headers[ 'content-encoding'] === 'deflate') stream = res.pipe(zl.createInflate());
 				}
 
 				let wumpRes;
 
 				if (this.o.streamed) resolve(stream);
 				else {
-					wumpRes = new WumpResponse(res);
+					wumpRes = new WumpRes(res);
 
 					if (res.headers.hasOwnProperty('location') && this.o.follow) {
-						this.o.url = (new URL(res.headers['location'], this.o.url)).toString();
+						this.o.url = (new u.URL(res.headers['location'], this.o.url)).toString();
 						return await w(this.o);
 					}
 
@@ -143,8 +144,8 @@ module.exports = class WumpRequest {
 				}
 			};
 
-			if (this.o.url.protocol === 'http:') req = http.request(options, handler);
-			else if (this.o.url.protocol === 'https:') req = https.request(options, handler);
+			if (this.o.url.protocol === 'http:') req = h.request(options, handler);
+			else if (this.o.url.protocol === 'https:') req = hs.request(options, handler);
 			else throw new Error(`Bad URL protocol: ${this.o.url.protocol}`);
 
 			if (this.o.timeoutTime) {


### PR DESCRIPTION
Here's what I did and why I did it:
* Remove README.md information about why use Wumpfetch - Users already know it's light from the start and from package phobia, no point adding extra unneeded information.
* Made gulpfile.js lighter - Made it like the other files
* Edit LICENSE - There was an unneeded gap
* Index.js modifications -  No longer does it hard code the package name and URL, making life easier for people forking it or using it in business. Also changed request to req to make it lighter!
* .gitignore edit - Removed unneeded "/"
* WumpRequest.js Improvements - Package name and URL are also no longer hard coded here, renamed consts to decrease file size.

Now under 10kb!

Let me know if anything needs editing